### PR TITLE
Scan providers local not global

### DIFF
--- a/sailbrowser-web/src/app/results-input/capture/capture.providers.ts
+++ b/sailbrowser-web/src/app/results-input/capture/capture.providers.ts
@@ -1,0 +1,8 @@
+import { ResultsSheetCaptureService } from './services/results-sheet-capture.service';
+import { ScannerPhoneCaptureService } from './services/scanner-phone-capture.service';
+
+/** Provide on each view that opens capture dialogs (scanner, manual results). */
+export const CAPTURE_PROVIDERS = [
+  ResultsSheetCaptureService,
+  ScannerPhoneCaptureService,
+] as const;

--- a/sailbrowser-web/src/app/results-input/capture/index.ts
+++ b/sailbrowser-web/src/app/results-input/capture/index.ts
@@ -1,3 +1,4 @@
+export { CAPTURE_PROVIDERS } from './capture.providers';
 export {
   ResultsSheetCaptureService,
   type CaptureAndStoreOptions,

--- a/sailbrowser-web/src/app/results-input/capture/services/results-sheet-capture.service.ts
+++ b/sailbrowser-web/src/app/results-input/capture/services/results-sheet-capture.service.ts
@@ -27,7 +27,7 @@ export interface UploadInlineImageOptions {
   mimeType: string;
 }
 
-@Injectable({ providedIn: 'root' })
+@Injectable()
 export class ResultsSheetCaptureService {
   private readonly app = inject(FirebaseApp);
   private readonly dialog = inject(MatDialog);

--- a/sailbrowser-web/src/app/results-input/capture/services/scanner-phone-capture.service.ts
+++ b/sailbrowser-web/src/app/results-input/capture/services/scanner-phone-capture.service.ts
@@ -14,7 +14,7 @@ import { CaptureSession, CaptureSessionDoc, UploadFromSessionInput } from '../ca
  * document reference is scoped to the current club via
  * {@link FirestoreTenantService}.
  */
-@Injectable({ providedIn: 'root' })
+@Injectable()
 export class ScannerPhoneCaptureService {
   private readonly app = inject(FirebaseApp);
   private readonly tenant = inject(FirestoreTenantService);

--- a/sailbrowser-web/src/app/results-input/presentation/manual-results-page/manual-results-page.ts
+++ b/sailbrowser-web/src/app/results-input/presentation/manual-results-page/manual-results-page.ts
@@ -21,6 +21,7 @@ import { DialogsService } from 'app/shared/dialogs/dialogs.service';
 import { firstValueFrom, map } from 'rxjs';
 import { RaceTitlePipe } from '../../../shared/pipes/race-title-pipe';
 import { manualRaceTableSort, ManualResultsService } from '../../services/manual-results.service';
+import { CAPTURE_PROVIDERS } from '../../capture/capture.providers';
 import { ResultsSheetCaptureService } from '../../capture';
 import { HandicapInputPanel } from '../handicap/handicap-input-panel/handicap-input-panel';
 import { HandicapResultsTable } from '../handicap/handicap-results-table/handicap-results-table';
@@ -35,6 +36,7 @@ const SHEET_POPUP_FEATURES = 'popup,width=720,height=900';
   selector: 'app-manual-results-page',
   templateUrl: './manual-results-page.html',
   styleUrls: ['./manual-results-page.scss'],
+  providers: [...CAPTURE_PROVIDERS],
   imports: [
     Toolbar,
     MatButtonModule,

--- a/sailbrowser-web/src/app/results-input/scoring-sheet-scanner/review-save/review-step.ts
+++ b/sailbrowser-web/src/app/results-input/scoring-sheet-scanner/review-save/review-step.ts
@@ -9,7 +9,8 @@ import { RaceCompetitor } from '../../model/race-competitor';
 import { ScannedResultRow } from '../model/scan-model';
 import { formatScanMetricsSummary } from '../model/scan-metrics-format';
 import { ScanRunStore } from '../run-scan/scan-run.store';
-import { ScanReviewStore } from '../review-save/scan-review.store';
+import { ScanReviewStore } from './scan-review.store';
+import { ScanRowMatchingService } from './scan-row-matching.service';
 
 export interface MatchedRowVm {
   row: ScannedResultRow;
@@ -38,6 +39,7 @@ export interface AcceptanceChangedEvent {
     MatProgressBarModule,
     MatTableModule,
   ],
+  providers: [ScanReviewStore, ScanRowMatchingService],
   templateUrl: './review-step.html',
   styleUrl: './review-step.scss',
 })

--- a/sailbrowser-web/src/app/results-input/scoring-sheet-scanner/review-save/scan-row-matching.service.ts
+++ b/sailbrowser-web/src/app/results-input/scoring-sheet-scanner/review-save/scan-row-matching.service.ts
@@ -24,7 +24,7 @@ export function boatClassesMatch(a: string | undefined | null, b: string | undef
  * (boats, classes, resolved competitors, race) as arguments so it stays free of
  * store/signal dependencies and is easy to unit test.
  */
-@Injectable({ providedIn: 'root' })
+@Injectable()
 export class ScanRowMatchingService {
   private readonly allowedResultCodes = new Set<string>(RESULT_CODES as readonly string[]);
 

--- a/sailbrowser-web/src/app/results-input/scoring-sheet-scanner/run-scan/scan-execution.service.ts
+++ b/sailbrowser-web/src/app/results-input/scoring-sheet-scanner/run-scan/scan-execution.service.ts
@@ -12,7 +12,7 @@ const UPLOAD_RESULTS_SHEET_IMAGE_CALLABLE_TIMEOUT_MS = 120_000;
  * Drives a live scan run: uploads the sheet (when not already stored), calls the
  * parse callable, streams staged progress messages, and formats callable errors.
  */
-@Injectable({ providedIn: 'root' })
+@Injectable()
 export class ScanExecutionService {
   private readonly app = inject(FirebaseApp);
 

--- a/sailbrowser-web/src/app/results-input/scoring-sheet-scanner/scoring-sheet-scanner.ts
+++ b/sailbrowser-web/src/app/results-input/scoring-sheet-scanner/scoring-sheet-scanner.ts
@@ -1,13 +1,15 @@
 import { afterNextRender, Component, computed, effect, inject, Injector, signal, untracked, viewChild } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatStepper, MatStepperModule } from '@angular/material/stepper';
+import { CAPTURE_PROVIDERS } from '../capture/capture.providers';
 import { CaptureStep, CaptureStepViewModel } from '../capture/capture-step/capture-step';
 import { Toolbar } from 'app/shared/components/toolbar';
 import { AppBreakpoints } from 'app/shared/services/breakpoints';
 import { SheetCaptureStore } from './capture-image/sheet-capture.store';
+import { ScanExecutionService } from './run-scan/scan-execution.service';
 import { ScanRunStore } from './run-scan/scan-run.store';
-import { ScanReviewStore } from './review-save/scan-review.store';
 import { ReviewStep } from './review-save/review-step';
+import { ScanPersistenceService } from './shared/scan-persistence.service';
 import { RaceSelectionStore } from './select-race/race-selection.store';
 import { RaceStep } from './select-race/race-step';
 import { SetupStep } from './run-scan/setup-step';
@@ -20,7 +22,14 @@ const REVIEW_STEP_INDEX = 3;
   imports: [MatStepperModule, MatButtonModule, Toolbar, RaceStep, CaptureStep, SetupStep, ReviewStep],
   templateUrl: './scoring-sheet-scanner.html',
   styleUrl: './scoring-sheet-scanner.scss',
-  providers: [RaceSelectionStore, SheetCaptureStore, ScanRunStore, ScanReviewStore],
+  providers: [
+    ...CAPTURE_PROVIDERS,
+    RaceSelectionStore,
+    SheetCaptureStore,
+    ScanRunStore,
+    ScanPersistenceService,
+    ScanExecutionService,
+  ],
 })
 export class ScoringSheetScanner {
   private readonly injector = inject(Injector);
@@ -28,7 +37,6 @@ export class ScoringSheetScanner {
   protected readonly raceSelection = inject(RaceSelectionStore);
   protected readonly sheetCapture = inject(SheetCaptureStore);
   protected readonly scanRun = inject(ScanRunStore);
-  protected readonly review = inject(ScanReviewStore);
 
   readonly isMobile = this.breakpoints.isMobile;
   protected readonly capturePersisting = signal(false);

--- a/sailbrowser-web/src/app/results-input/scoring-sheet-scanner/shared/scan-persistence.service.ts
+++ b/sailbrowser-web/src/app/results-input/scoring-sheet-scanner/shared/scan-persistence.service.ts
@@ -13,7 +13,7 @@ interface ScanResultDoc {
  * references come from {@link FirestoreTenantService}, which scopes them to the
  * current club tenant.
  */
-@Injectable({ providedIn: 'root' })
+@Injectable()
 export class ScanPersistenceService {
   private readonly tenant = inject(FirestoreTenantService);
 


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Scope results-input capture/scanner services to local component providers
<code>🐞 Bug fix</code> <code>✨ Enhancement</code> <code>🕐 20-40 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>Description</summary>

<br/>

<pre>
• Move capture/scanner services from root singletons to view-scoped providers.
• Add shared CAPTURE_PROVIDERS constant for consistent per-view DI wiring.
• Localize review-step matching/review dependencies to avoid cross-flow instance sharing.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  MRP["Manual Results Page"] --> CP["CAPTURE_PROVIDERS"] --> CS("Capture services")
  SSS["Scoring Sheet Scanner"] --> CP --> CS
  SSS --> SS("Scan services")
  RS["Review Step"] --> RVS("Review services")
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Use `providedIn: &#x27;any&#x27;` for feature scoping</b></summary>

- ➕ Reduces root-singleton sharing while keeping services tree-shakable
- ➕ Less manual provider wiring in components
- ➖ Scope is per-injector boundary and can be non-obvious (lazy modules/routes)
- ➖ Doesn’t guarantee per-view isolation when multiple instances exist in one injector tree

</details>

<details>
<summary><b>2. Provide services at the route level (route `providers`)</b></summary>

- ➕ Keeps components simpler while still avoiding global singletons
- ➕ Clear lifecycle tied to route activation
- ➖ Less flexible if multiple pages/entry points need the same provider set
- ➖ Requires keeping route config aligned with component usage

</details>

<details>
<summary><b>3. Create a dedicated ResultsInput feature module and provide there</b></summary>

- ➕ Centralizes provider configuration in one place
- ➕ Avoids repeating providers across multiple components
- ➖ Module-level scope may still be broader than desired (not per-page instance)
- ➖ More structural churn if the app is moving toward standalone-first patterns

</details>

**Recommendation:** Current approach (explicit component-level providers + shared CAPTURE_PROVIDERS constant) is the most predictable way to ensure per-view instances and prevent unintended singleton sharing across capture/scanner flows. Alternatives like `providedIn: &#x27;any&#x27;` or module-level providers reduce global scope, but they’re less explicit about lifecycle and can still lead to surprising instance sharing depending on injector boundaries.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Bug fix</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>results-sheet-capture.service.ts</strong> <code>Stop providing ResultsSheetCaptureService as a root singleton</code> <code>+1/-1</code></summary>

<br/>

>Stop providing ResultsSheetCaptureService as a root singleton
>
><pre>
>• Removes &#x27;providedIn: &#x27;root&#x27;&#x27; so the service must be provided by the consuming view/component. This prevents sharing the same instance across unrelated flows.
></pre>
>
><a href='https://github.com/daveryderoxford/ScoreSmarter/pull/61/files#diff-9f951a61e011ab86fa314feea63d312fee5e2dd0036f09add35fa23116499c82'>sailbrowser-web/src/app/results-input/capture/services/results-sheet-capture.service.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>scanner-phone-capture.service.ts</strong> <code>Stop providing ScannerPhoneCaptureService as a root singleton</code> <code>+1/-1</code></summary>

<br/>

>Stop providing ScannerPhoneCaptureService as a root singleton
>
><pre>
>• Removes &#x27;providedIn: &#x27;root&#x27;&#x27; to force local provisioning and avoid accidental cross-view instance reuse.
></pre>
>
><a href='https://github.com/daveryderoxford/ScoreSmarter/pull/61/files#diff-a693918210ae4a2d7ece0e6adb94599c05612abebf5dcce18ffe3f344dcf1ac7'>sailbrowser-web/src/app/results-input/capture/services/scanner-phone-capture.service.ts</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Refactor</strong> (8)</summary>

<blockquote>
<details>
<summary><strong>capture.providers.ts</strong> <code>Add CAPTURE_PROVIDERS for per-view capture DI wiring</code> <code>+8/-0</code></summary>

<br/>

>Add CAPTURE_PROVIDERS for per-view capture DI wiring
>
><pre>
>• Introduces a shared provider array containing the capture services. Intended to be spread into the &#x27;providers&#x27; of each view that opens capture dialogs to ensure local scoping.
></pre>
>
><a href='https://github.com/daveryderoxford/ScoreSmarter/pull/61/files#diff-682d4febf32c0234cde6a2f4ea73dd33c620ab75841edbf75aa314cfe537dbf9'>sailbrowser-web/src/app/results-input/capture/capture.providers.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>index.ts</strong> <code>Export CAPTURE_PROVIDERS from capture barrel</code> <code>+1/-0</code></summary>

<br/>

>Export CAPTURE_PROVIDERS from capture barrel
>
><pre>
>• Updates the capture index barrel to re-export the new CAPTURE_PROVIDERS constant for easier consumption by feature components.
></pre>
>
><a href='https://github.com/daveryderoxford/ScoreSmarter/pull/61/files#diff-be4ca275519999fd73f1c65bcc0c55b995993a81a2aa072b94ab826857b93485'>sailbrowser-web/src/app/results-input/capture/index.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>manual-results-page.ts</strong> <code>Provide capture services at ManualResultsPage level</code> <code>+2/-0</code></summary>

<br/>

>Provide capture services at ManualResultsPage level
>
><pre>
>• Adds CAPTURE_PROVIDERS to the component providers so capture dialogs opened from manual results use view-scoped service instances.
></pre>
>
><a href='https://github.com/daveryderoxford/ScoreSmarter/pull/61/files#diff-2471362bd3e900d4ea5f5202d3a692319e9edab0959d9f6420e33918f46c65a4'>sailbrowser-web/src/app/results-input/presentation/manual-results-page/manual-results-page.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>review-step.ts</strong> <code>Localize review dependencies and fix ScanReviewStore import path</code> <code>+3/-1</code></summary>

<br/>

>Localize review dependencies and fix ScanReviewStore import path
>
><pre>
>• Adjusts the import to use the local &#x27;./scan-review.store&#x27; path and adds component-level providers for ScanReviewStore and ScanRowMatchingService to avoid global sharing.
></pre>
>
><a href='https://github.com/daveryderoxford/ScoreSmarter/pull/61/files#diff-ed8f122cc5f47091a813df1f20fc6e9775a243ccaacdf987015774689aebb6a2'>sailbrowser-web/src/app/results-input/scoring-sheet-scanner/review-save/review-step.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>scan-row-matching.service.ts</strong> <code>Stop providing ScanRowMatchingService as a root singleton</code> <code>+1/-1</code></summary>

<br/>

>Stop providing ScanRowMatchingService as a root singleton
>
><pre>
>• Removes &#x27;providedIn: &#x27;root&#x27;&#x27; so the matching service is scoped to the review step where it’s used.
></pre>
>
><a href='https://github.com/daveryderoxford/ScoreSmarter/pull/61/files#diff-a4b1e2336b1fbfda2e949398c7f26496d7712cd52a41a362e78e32b099e21ca1'>sailbrowser-web/src/app/results-input/scoring-sheet-scanner/review-save/scan-row-matching.service.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>scan-execution.service.ts</strong> <code>Stop providing ScanExecutionService as a root singleton</code> <code>+1/-1</code></summary>

<br/>

>Stop providing ScanExecutionService as a root singleton
>
><pre>
>• Removes &#x27;providedIn: &#x27;root&#x27;&#x27;, requiring explicit provisioning by the scanner flow to keep scan execution state/lifecycle local.
></pre>
>
><a href='https://github.com/daveryderoxford/ScoreSmarter/pull/61/files#diff-c65e48fd51122c09256a040e7e22458c6dead5157a5a9d6cebb7e0737a46a675'>sailbrowser-web/src/app/results-input/scoring-sheet-scanner/run-scan/scan-execution.service.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>scoring-sheet-scanner.ts</strong> <code>Scope scanner flow dependencies via component providers</code> <code>+11/-3</code></summary>

<br/>

>Scope scanner flow dependencies via component providers
>
><pre>
>• Adds CAPTURE_PROVIDERS and explicitly provides scan persistence/execution services at the scanner component level. Removes ScanReviewStore from the scanner-level provider list (now provided by the review step).
></pre>
>
><a href='https://github.com/daveryderoxford/ScoreSmarter/pull/61/files#diff-2014a541a16f59f4738a60368a3bb2b0f85aad0bf8c2baa1f9c1ed324243fb8d'>sailbrowser-web/src/app/results-input/scoring-sheet-scanner/scoring-sheet-scanner.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>scan-persistence.service.ts</strong> <code>Stop providing ScanPersistenceService as a root singleton</code> <code>+1/-1</code></summary>

<br/>

>Stop providing ScanPersistenceService as a root singleton
>
><pre>
>• Removes &#x27;providedIn: &#x27;root&#x27;&#x27; so persistence is scoped to the scanner flow, aligning lifecycle with the owning feature component.
></pre>
>
><a href='https://github.com/daveryderoxford/ScoreSmarter/pull/61/files#diff-bfdcdf0a89612ce59c453e2979f0768a70e9635c4ca5b1261bb3ff78b1ddef81'>sailbrowser-web/src/app/results-input/scoring-sheet-scanner/shared/scan-persistence.service.ts</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>