### PR TITLE
Home screen satrtup optimisation.

### DIFF
--- a/sailbrowser-web/src/app/app.html
+++ b/sailbrowser-web/src/app/app.html
@@ -1,7 +1,9 @@
 <mat-sidenav-container class="clipped-container">
 
   <mat-sidenav #sidenav>
-    <app-sidenav-menu />
+    @defer (when sidenavService.menuRequested()) {
+      <app-sidenav-menu />
+    }
   </mat-sidenav>
 
 <mat-sidenav-content class="clipped-container">

--- a/sailbrowser-web/src/app/app.ts
+++ b/sailbrowser-web/src/app/app.ts
@@ -6,8 +6,8 @@ import { SidenavService } from './shared/services/sidenav.service';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { filter, map } from 'rxjs/operators';
 import { MatProgressBarModule } from "@angular/material/progress-bar";
-import { SidenavMenu } from './sidenav-menu/presentation/sidenav-menu';
 import { MatSidenav, MatSidenavModule } from '@angular/material/sidenav';
+import { SidenavMenu } from './sidenav-menu/presentation/sidenav-menu';
 
 @Component({
   selector: 'app-root',
@@ -17,7 +17,7 @@ import { MatSidenav, MatSidenavModule } from '@angular/material/sidenav';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class App implements OnInit {
-  sidebarService = inject(SidenavService);
+  protected readonly sidenavService = inject(SidenavService);
   private appUpdate = inject(AppUpdateService);
   private lazyInject = inject(LazyInject);
   private router = inject(Router);
@@ -34,7 +34,7 @@ export class App implements OnInit {
 
   ngOnInit() {
     console.log('App component: Initializing...');
-    this.sidebarService.setSidenav(this.sidenav());
+    this.sidenavService.setSidenav(this.sidenav());
     this.appUpdate.initialize();
     this.cookieConsent();
   }

--- a/sailbrowser-web/src/app/club-admin/presentation/club-settings/club-settings.html
+++ b/sailbrowser-web/src/app/club-admin/presentation/club-settings/club-settings.html
@@ -9,11 +9,18 @@
   <mat-card class="config-card">
     <mat-card-content>
       <div class="logo-row">
-        <app-club-logo
-          [src]="logoDisplayUrl()"
-          size="lg"
-          [showPlaceholder]="false"
-          alt="Club logo preview" />
+        @if (pendingLogoPreviewUrl(); as previewUrl) {
+          <img
+            class="logo-preview"
+            [src]="previewUrl"
+            alt="Club logo preview"
+            referrerpolicy="no-referrer" />
+        } @else {
+          <app-club-logo
+            size="lg"
+            [showPlaceholder]="false"
+            alt="Club logo preview" />
+        }
         <div class="logo-upload">
           <label class="upload-label">
             <span>Upload logo image</span>

--- a/sailbrowser-web/src/app/club-admin/presentation/club-settings/club-settings.scss
+++ b/sailbrowser-web/src/app/club-admin/presentation/club-settings/club-settings.scss
@@ -47,6 +47,15 @@
   margin-bottom: 1rem;
 }
 
+.logo-preview {
+  width: 96px;
+  height: 96px;
+  border-radius: 50%;
+  object-fit: cover;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  flex-shrink: 0;
+}
+
 .logo-upload {
   flex: 1;
 }

--- a/sailbrowser-web/src/app/club-admin/presentation/club-settings/club-settings.ts
+++ b/sailbrowser-web/src/app/club-admin/presentation/club-settings/club-settings.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, effect, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, inject, signal } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
@@ -42,12 +42,6 @@ export class ClubSettingsComponent {
   readonly pendingLogoPreviewUrl = signal<string | null>(null);
   readonly hasPendingLogo = signal(false);
   private pendingLogoFile: File | null = null;
-
-  readonly logoDisplayUrl = computed(() =>
-    this.hasPendingLogo()
-      ? this.pendingLogoPreviewUrl()
-      : this.clubLogoService.logoDownloadUrl(),
-  );
 
   readonly form = this.fb.group({
     name: ['', Validators.required],

--- a/sailbrowser-web/src/app/club-admin/services/club-logo.service.ts
+++ b/sailbrowser-web/src/app/club-admin/services/club-logo.service.ts
@@ -2,8 +2,8 @@ import { Injectable, computed, inject } from '@angular/core';
 import { rxResource } from '@angular/core/rxjs-interop';
 import { FirebaseApp } from '@angular/fire/app';
 import { connectFunctionsEmulator, getFunctions, httpsCallable } from 'firebase/functions';
-import { getDownloadURL, getStorage, ref as storageRef } from 'firebase/storage';
 import { ClubStore } from 'app/club-tenant';
+import { resolveStorageDownloadUrl } from 'app/shared/firebase/storage-download';
 import { from, of } from 'rxjs';
 import { environment } from '../../../environments/environment';
 
@@ -27,7 +27,7 @@ export class ClubLogoService {
       if (!trimmed) {
         return of(null);
       }
-      return from(getDownloadURL(storageRef(getStorage(this.app), trimmed)));
+      return from(resolveStorageDownloadUrl(this.app, trimmed));
     },
     defaultValue: null,
   });

--- a/sailbrowser-web/src/app/home/presentation/home-page.html
+++ b/sailbrowser-web/src/app/home/presentation/home-page.html
@@ -12,7 +12,6 @@
   <mat-card class="home-card">
     <div class="club-header">
       <app-club-logo
-        [src]="clubLogoService.logoDownloadUrl()"
         size="lg"
         [showPlaceholder]="false"
         alt="Club logo" />
@@ -46,21 +45,11 @@
         </a>
       </div>
 
-      <div class="races-section">
-        @if (currentRacesStore.todaysRaces().length > 0) {
-          <h2 class="races-title">Races Today</h2>
-          <mat-list>
-            @for (race of currentRacesStore.todaysRaces(); track race.id) {
-              <mat-list-item>
-                <span matListItemTitle>{{ race.seriesName }} - Race {{ race.raceOfDay }}</span>
-                <span matListItemLine>{{ race.scheduledStart | date:'shortTime' }}</span>
-              </mat-list-item>
-            }
-          </mat-list>
-        } @else {
-          <p class="placeholder">No races scheduled for today.</p>
-        }
-      </div>
+      @defer (on idle) {
+        <app-home-races-section />
+      } @placeholder {
+        <p class="placeholder">Loading today's races…</p>
+      }
     </mat-card-content>
   </mat-card>
 </div>

--- a/sailbrowser-web/src/app/home/presentation/home-page.scss
+++ b/sailbrowser-web/src/app/home/presentation/home-page.scss
@@ -77,17 +77,6 @@
   }
 }
 
-.races-section {
-  margin-top: 16px;
-}
-
-.races-title {
-  text-align: center;
-  font: var(--mat-sys-title-large);
-  color: var(--mat-sys-on-surface-variant);
-  margin-bottom: 16px;
-}
-
 .placeholder {
   padding: 15px;
   text-align: center;

--- a/sailbrowser-web/src/app/home/presentation/home-page.ts
+++ b/sailbrowser-web/src/app/home/presentation/home-page.ts
@@ -1,17 +1,14 @@
-import { DatePipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, effect, inject } from '@angular/core';
-import { ClubLogoService } from 'app/club-admin/services/club-logo.service';
 import { ClubLogo } from 'app/shared/components/club-logo/club-logo';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
-import { MatListModule } from '@angular/material/list';
 import { MatCardModule } from '@angular/material/card';
 import { MatMenuModule } from '@angular/material/menu';
 import { RouterLink } from '@angular/router';
-import { CurrentRaces } from '../../results-input/services/current-races-store';
 import { ClubStore } from 'app/club-tenant';
 import { Toolbar } from 'app/shared/components/toolbar';
 import { Title } from '@angular/platform-browser';
+import { HomeRacesSection } from './home-races-section';
 
 @Component({
   selector: 'app-home',
@@ -21,27 +18,22 @@ import { Title } from '@angular/platform-browser';
     Toolbar,
     MatButtonModule,
     RouterLink,
-    MatListModule,
-    DatePipe,
     MatIconModule,
     MatCardModule,
     MatMenuModule,
     ClubLogo,
+    HomeRacesSection,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class HomePage {
-  protected readonly currentRacesStore = inject(CurrentRaces);
   protected readonly clubStore = inject(ClubStore);
-  protected readonly clubLogoService = inject(ClubLogoService);
   private readonly pageTitle = inject(Title);
 
-  title = computed( () => {
+  title = computed(() => {
     const club = this.clubStore.club();
     return ' ScoreSmarter:  ' + (club.shortName ?? club.name);
-      });
+  });
 
-  pageTitleEffect = effect(() =>
-    this.pageTitle.setTitle(this.title()));
-
+  pageTitleEffect = effect(() => this.pageTitle.setTitle(this.title()));
 }

--- a/sailbrowser-web/src/app/home/presentation/home-races-section.ts
+++ b/sailbrowser-web/src/app/home/presentation/home-races-section.ts
@@ -1,0 +1,49 @@
+import { DatePipe } from '@angular/common';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { MatListModule } from '@angular/material/list';
+import { CurrentRaces } from 'app/results-input/services/current-races-store';
+
+@Component({
+  selector: 'app-home-races-section',
+  imports: [MatListModule, DatePipe],
+  template: `
+    <div class="races-section">
+      @if (currentRaces.todaysRaces().length > 0) {
+        <h2 class="races-title">Races Today</h2>
+        <mat-list>
+          @for (race of currentRaces.todaysRaces(); track race.id) {
+            <mat-list-item>
+              <span matListItemTitle>{{ race.seriesName }} - Race {{ race.raceOfDay }}</span>
+              <span matListItemLine>{{ race.scheduledStart | date:'shortTime' }}</span>
+            </mat-list-item>
+          }
+        </mat-list>
+      } @else {
+        <p class="placeholder">No races scheduled for today.</p>
+      }
+    </div>
+  `,
+  styles: `
+    .races-section {
+      margin-top: 16px;
+    }
+
+    .races-title {
+      text-align: center;
+      font: var(--mat-sys-title-large);
+      color: var(--mat-sys-on-surface-variant);
+      margin-bottom: 16px;
+    }
+
+    .placeholder {
+      padding: 15px;
+      text-align: center;
+      font: var(--mat-sys-body-large);
+      color: var(--mat-sys-on-surface-variant);
+    }
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class HomeRacesSection {
+  protected readonly currentRaces = inject(CurrentRaces);
+}

--- a/sailbrowser-web/src/app/results-input/capture/services/results-sheet-capture.service.ts
+++ b/sailbrowser-web/src/app/results-input/capture/services/results-sheet-capture.service.ts
@@ -2,7 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import { FirebaseApp } from '@angular/fire/app';
 import { MatDialog } from '@angular/material/dialog';
 import { connectFunctionsEmulator, getFunctions, httpsCallable } from 'firebase/functions';
-import { getDownloadURL, getStorage, ref as storageRef } from 'firebase/storage';
+import { resolveStorageDownloadUrl } from 'app/shared/firebase/storage-download';
 import { firstValueFrom } from 'rxjs';
 import { environment } from '../../../../environments/environment';
 import {
@@ -35,7 +35,7 @@ export class ResultsSheetCaptureService {
   async resolveDownloadUrl(path: string | null | undefined): Promise<string | null> {
     const trimmed = path?.trim();
     if (!trimmed) return null;
-    return await getDownloadURL(storageRef(getStorage(this.app), trimmed));
+    return await resolveStorageDownloadUrl(this.app, trimmed);
   }
 
   async uploadInlineImage(

--- a/sailbrowser-web/src/app/shared/components/club-logo/club-logo.html
+++ b/sailbrowser-web/src/app/shared/components/club-logo/club-logo.html
@@ -1,6 +1,6 @@
-@if (src()) {
+@if (logoUrl()) {
   <img
-    [src]="src()!"
+    [src]="logoUrl()!"
     [alt]="alt()"
     class="club-logo"
     referrerpolicy="no-referrer" />

--- a/sailbrowser-web/src/app/shared/components/club-logo/club-logo.ts
+++ b/sailbrowser-web/src/app/shared/components/club-logo/club-logo.ts
@@ -1,5 +1,6 @@
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
+import { ClubLogoService } from 'app/club-admin/services/club-logo.service';
 
 @Component({
   selector: 'app-club-logo',
@@ -14,8 +15,11 @@ import { MatIconModule } from '@angular/material/icon';
   },
 })
 export class ClubLogo {
-  readonly src = input<string | null>(null);
+  private readonly clubLogoService = inject(ClubLogoService);
+
   readonly alt = input('Club logo');
   readonly size = input<'sm' | 'lg'>('sm');
   readonly showPlaceholder = input(true);
+
+  protected readonly logoUrl = this.clubLogoService.logoDownloadUrl;
 }

--- a/sailbrowser-web/src/app/shared/firebase/storage-download.ts
+++ b/sailbrowser-web/src/app/shared/firebase/storage-download.ts
@@ -1,0 +1,7 @@
+import type { FirebaseApp } from '@angular/fire/app';
+
+/** Lazy-loads the Storage SDK and resolves a download URL for an object path. */
+export async function resolveStorageDownloadUrl(app: FirebaseApp, path: string): Promise<string> {
+  const { getDownloadURL, getStorage, ref } = await import('firebase/storage');
+  return getDownloadURL(ref(getStorage(app), path));
+}

--- a/sailbrowser-web/src/app/shared/services/app-update.service.ts
+++ b/sailbrowser-web/src/app/shared/services/app-update.service.ts
@@ -1,8 +1,18 @@
-import { DestroyRef, Injectable, inject, isDevMode } from '@angular/core';
+import {
+  DestroyRef,
+  EnvironmentInjector,
+  Injectable,
+  afterNextRender,
+  inject,
+  isDevMode,
+} from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { SwUpdate, VersionReadyEvent } from '@angular/service-worker';
-import { filter, fromEvent } from 'rxjs';
+import { concat, filter, from, fromEvent, interval } from 'rxjs';
+
+/** How often to poll for a new deployment once the service worker is active. */
+const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
 
 @Injectable({
   providedIn: 'root',
@@ -10,6 +20,7 @@ import { filter, fromEvent } from 'rxjs';
 export class AppUpdateService {
   private readonly swUpdate = inject(SwUpdate);
   private readonly snackbar = inject(MatSnackBar);
+  private readonly envInjector = inject(EnvironmentInjector);
   private readonly destroyRef = inject(DestroyRef);
 
   private updatePromptOpen = false;
@@ -30,15 +41,36 @@ export class AppUpdateService {
       this.promptReload('Something went wrong. Reload to continue.');
     });
 
-    void this.checkForUpdate();
+    if ('serviceWorker' in navigator) {
+      // Zoneless: avoid ApplicationRef.isStable — it becomes true immediately and
+      // RxJS interval before stability blocks SW registration. Wait for the SW to
+      // be active, then poll on a fixed interval.
+      concat(
+        from(navigator.serviceWorker.ready.then(() => undefined)),
+        interval(UPDATE_CHECK_INTERVAL_MS),
+      )
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe(() => void this.checkForUpdate());
+    }
 
     fromEvent(document, 'visibilitychange')
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(() => {
-        if (document.visibilityState === 'visible') {
-          void this.checkForUpdate();
-        }
-      });
+      .pipe(
+        filter(() => document.visibilityState === 'visible'),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => void this.checkForUpdate());
+  }
+
+  private async checkForUpdate(): Promise<void> {
+    if (!('serviceWorker' in navigator)) {
+      return;
+    }
+    try {
+      await navigator.serviceWorker.ready;
+      await this.swUpdate.checkForUpdate();
+    } catch {
+      /* SW not controlling the page yet */
+    }
   }
 
   private promptReload(message = 'A new version is available.'): void {
@@ -47,21 +79,24 @@ export class AppUpdateService {
     }
 
     this.updatePromptOpen = true;
-    const ref = this.snackbar.open(message, 'Reload');
 
-    ref.onAction().subscribe(() => {
-      void this.swUpdate.activateUpdate().then(
-        () => location.reload(),
-        () => location.reload(),
-      );
-    });
+    // Zoneless: VERSION_READY arrives outside Angular — schedule UI on the next render.
+    afterNextRender(
+      () => {
+        const ref = this.snackbar.open(message, 'Reload', { politeness: 'assertive' });
 
-    ref.afterDismissed().subscribe(() => {
-      this.updatePromptOpen = false;
-    });
-  }
+        ref.onAction().subscribe(() => {
+          void this.swUpdate.activateUpdate().then(
+            () => location.reload(),
+            () => location.reload(),
+          );
+        });
 
-  private checkForUpdate(): Promise<boolean> {
-    return this.swUpdate.checkForUpdate().catch(() => false);
+        ref.afterDismissed().subscribe(() => {
+          this.updatePromptOpen = false;
+        });
+      },
+      { injector: this.envInjector },
+    );
   }
 }

--- a/sailbrowser-web/src/app/shared/services/sidenav.service.ts
+++ b/sailbrowser-web/src/app/shared/services/sidenav.service.ts
@@ -1,28 +1,30 @@
-import { Injectable } from '@angular/core';
+import { Injectable, signal } from '@angular/core';
 import { MatSidenav } from '@angular/material/sidenav';
 
-@Injectable( {
-   providedIn: 'root'
-} )
+@Injectable({
+  providedIn: 'root',
+})
 export class SidenavService {
+  private sidenav: MatSidenav | null = null;
 
-   private sidenav: MatSidenav | null = null;
+  /** Set when the user first opens or toggles the sidenav; triggers lazy menu load. */
+  readonly menuRequested = signal(false);
 
-   constructor () { }
+  public setSidenav(sidenav: MatSidenav) {
+    this.sidenav = sidenav;
+  }
 
-   public setSidenav( sidenav: MatSidenav ) {
-      this.sidenav = sidenav;
-   }
+  public open() {
+    this.menuRequested.set(true);
+    return this.sidenav!.open();
+  }
 
-   public open() {
-      return this.sidenav!.open();
-   }
+  public close() {
+    return this.sidenav!.close();
+  }
 
-   public close() {
-      return this.sidenav!.close();
-   }
-
-   public toggle(): void {
-      this.sidenav!.toggle();
-   }
+  public toggle(): void {
+    this.menuRequested.set(true);
+    this.sidenav!.toggle();
+  }
 }

--- a/sailbrowser-web/src/app/sidenav-menu/presentation/sidenav-menu.html
+++ b/sailbrowser-web/src/app/sidenav-menu/presentation/sidenav-menu.html
@@ -1,7 +1,6 @@
 <div class="sidenav-root">
   <header class="club-branding">
     <app-club-logo
-      [src]="clubLogoService.logoDownloadUrl()"
       [alt]="clubDisplayName() + ' logo'"
       size="sm" />
     @if (clubWebsiteUrl(); as website) {

--- a/sailbrowser-web/src/app/sidenav-menu/presentation/sidenav-menu.ts
+++ b/sailbrowser-web/src/app/sidenav-menu/presentation/sidenav-menu.ts
@@ -6,7 +6,6 @@ import { MatDividerModule } from '@angular/material/divider';
 import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
 import { AuthService } from 'app/auth';
-import { ClubLogoService } from 'app/club-admin/services/club-logo.service';
 import { ClubStore } from 'app/club-tenant';
 import { ClubLogo } from 'app/shared/components/club-logo/club-logo';
 import { SidenavService } from 'app/shared/services/sidenav.service';
@@ -112,7 +111,6 @@ export class SidenavMenu {
   };
   private readonly userData = inject(UserDataService);
   protected readonly clubStore = inject(ClubStore);
-  protected readonly clubLogoService = inject(ClubLogoService);
 
   protected readonly club = computed(() => this.clubStore.club());
 


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Optimize startup by deferring heavy home/sidenav UI and lazy-loading Firebase Storage
<code>✨ Enhancement</code> <code>🐞 Bug fix</code> <code>🕐 40+ Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>Description</summary>

<br/>

<pre>
• Defer sidenav menu and “Races Today” rendering to reduce initial home screen work.
• Lazy-load Firebase Storage SDK when resolving download URLs to shrink startup bundle.
• Make service-worker update checks zoneless-safe and avoid premature polling/UI timing issues.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["App shell"] --> B(["SidenavService"])
  B --> C["SidenavMenu (deferred)"]
  A --> D(["AppUpdate checks"])
  E["HomePage"] --> F["HomeRacesSection (deferred)"]
  G["ClubLogo"] --> H(["Storage URL resolver"])

  subgraph Legend
    direction LR
    _cmp["Component"] ~~~ _svc(["Service/Logic"])
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Route-level lazy loading instead of template @defer</b></summary>

- ➕ Clearer loading boundaries (entire feature chunks) and predictable code-splitting
- ➕ Avoids partial-template placeholders and component extraction churn
- ➖ Less targeted: you may end up delaying more UI than necessary
- ➖ Doesn’t help for content that must live on the same route (e.g., sidenav within app shell)

</details>

<details>
<summary><b>2. Prefetch deferred chunks (hover/idle) with explicit prefetch triggers</b></summary>

- ➕ Keeps fast first paint while reducing perceived latency when user opens sidenav
- ➕ Can be tuned (idle/interaction/viewport) per device/network
- ➖ Adds complexity and can regress bandwidth usage on constrained clients
- ➖ Requires careful measurement to avoid reintroducing startup cost

</details>

<details>
<summary><b>3. Keep ClubLogo as pure presentational component (continue passing [src])</b></summary>

- ➕ Lower coupling: ClubLogo stays reusable and easier to test
- ➕ Avoids hidden network/service dependencies in a leaf UI component
- ➖ Call sites must handle URL resolution consistently
- ➖ Harder to ensure Storage SDK is only loaded when truly needed

</details>

**Recommendation:** The PR’s approach is sound for startup optimization: use @defer to push non-critical UI work off the critical path and lazy-load Firebase Storage only when URLs are actually needed. The main trade-off is increased coupling in ClubLogo (it now depends on ClubLogoService); if reuse beyond the club-tenant context is expected, consider reintroducing an optional [src] override while keeping the service-backed default.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (10)</summary>

<blockquote>
<details>
<summary><strong>app.html</strong> <code>Defer sidenav menu creation until first request</code> <code>+3/-1</code></summary>

<br/>

>Defer sidenav menu creation until first request
>
><pre>
>• Wraps &lt;app-sidenav-menu /&gt; in an Angular @defer block that activates only when the sidenav service indicates the menu was requested. This reduces initial render/JS work on app startup.
></pre>
>
><a href='https://github.com/daveryderoxford/ScoreSmarter/pull/62/files#diff-2bfcec1307e306c93bef62f10f94989cb7ad897d16a261bc4a46c2eba47ee128'>sailbrowser-web/src/app/app.html</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>club-settings.html</strong> <code>Show pending logo preview via &lt;img&gt; and fall back to ClubLogo</code> <code>+12/-5</code></summary>

<br/>

>Show pending logo preview via &lt;img&gt; and fall back to ClubLogo
>
><pre>
>• Uses @if to render a direct &lt;img&gt; preview when a pending logo URL exists, otherwise renders &lt;app-club-logo&gt;. This avoids passing explicit logo URLs through the ClubLogo component.
></pre>
>
><a href='https://github.com/daveryderoxford/ScoreSmarter/pull/62/files#diff-c27f0fe19c365b8cbbb7958fab0646dfa9fd7da1a817679706a5f97add21e4d9'>sailbrowser-web/src/app/club-admin/presentation/club-settings/club-settings.html</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>club-settings.scss</strong> <code>Add styling for pending logo preview image</code> <code>+9/-0</code></summary>

<br/>

>Add styling for pending logo preview image
>
><pre>
>• Introduces .logo-preview styles (size, circular crop, shadow) for the new &lt;img&gt; preview path in club settings.
></pre>
>
><a href='https://github.com/daveryderoxford/ScoreSmarter/pull/62/files#diff-a77934438cad551840af1ce28574a2f3917f5b8c7b82b2b2e69ca42f3e82dc68'>sailbrowser-web/src/app/club-admin/presentation/club-settings/club-settings.scss</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>club-logo.service.ts</strong> <code>Lazy-load Firebase Storage when resolving club logo URLs</code> <code>+2/-2</code></summary>

<br/>

>Lazy-load Firebase Storage when resolving club logo URLs
>
><pre>
>• Replaces direct firebase/storage imports and getDownloadURL usage with resolveStorageDownloadUrl(). This defers loading the Storage SDK until a URL is actually requested.
></pre>
>
><a href='https://github.com/daveryderoxford/ScoreSmarter/pull/62/files#diff-c8b47b9b37afd19252e2021d2a3b40f130abd4b69a9583f1f4e9a519bd803549'>sailbrowser-web/src/app/club-admin/services/club-logo.service.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>home-page.html</strong> <code>Defer races section rendering on idle with placeholder</code> <code>+6/-17</code></summary>

<br/>

>Defer races section rendering on idle with placeholder
>
><pre>
>• Extracts the “Races Today” block into a deferred component loaded on idle and adds a loading placeholder. Also removes explicit [src] binding for the club logo.
></pre>
>
><a href='https://github.com/daveryderoxford/ScoreSmarter/pull/62/files#diff-4c4e22b718a63bdc3a9cf94e1d4c3982199201dafecfbb7ac5948da2f706108f'>sailbrowser-web/src/app/home/presentation/home-page.html</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>home-races-section.ts</strong> <code>New deferred HomeRacesSection component for today’s races list</code> <code>+49/-0</code></summary>

<br/>

>New deferred HomeRacesSection component for today’s races list
>
><pre>
>• Adds a standalone component that renders today’s races using CurrentRaces, MatListModule, and DatePipe. This allows the home page to load the races UI lazily via @defer.
></pre>
>
><a href='https://github.com/daveryderoxford/ScoreSmarter/pull/62/files#diff-33c69befc10158be94661686d9cc5e7a1cb52a402f88049a31f7ccda3ebb933f'>sailbrowser-web/src/app/home/presentation/home-races-section.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>results-sheet-capture.service.ts</strong> <code>Lazy-load Firebase Storage when resolving results sheet URLs</code> <code>+2/-2</code></summary>

<br/>

>Lazy-load Firebase Storage when resolving results sheet URLs
>
><pre>
>• Switches resolveDownloadUrl() to use resolveStorageDownloadUrl() instead of directly importing firebase/storage APIs. This reduces initial bundle weight for flows that don’t need Storage.
></pre>
>
><a href='https://github.com/daveryderoxford/ScoreSmarter/pull/62/files#diff-9f951a61e011ab86fa314feea63d312fee5e2dd0036f09add35fa23116499c82'>sailbrowser-web/src/app/results-input/capture/services/results-sheet-capture.service.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>club-logo.ts</strong> <code>Make ClubLogo resolve its own URL via ClubLogoService</code> <code>+6/-2</code></summary>

<br/>

>Make ClubLogo resolve its own URL via ClubLogoService
>
><pre>
>• Removes the src input and injects ClubLogoService, exposing its logoDownloadUrl as logoUrl for template binding. This centralizes logo URL handling and supports Storage SDK lazy-loading behavior.
></pre>
>
><a href='https://github.com/daveryderoxford/ScoreSmarter/pull/62/files#diff-581b24b26079d44184ff3f62edaea2e6fee33179cea779a38d01b0ec325c320a'>sailbrowser-web/src/app/shared/components/club-logo/club-logo.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>storage-download.ts</strong> <code>Add helper to lazy-load firebase/storage and resolve download URLs</code> <code>+7/-0</code></summary>

<br/>

>Add helper to lazy-load firebase/storage and resolve download URLs
>
><pre>
>• Introduces resolveStorageDownloadUrl() which dynamically imports firebase/storage and returns a download URL for a given object path. Used by services to avoid eager Storage SDK loading.
></pre>
>
><a href='https://github.com/daveryderoxford/ScoreSmarter/pull/62/files#diff-8a59d0a0e8136bb17d31011177485ac6801e3712815e6328fade5e487e7b654a'>sailbrowser-web/src/app/shared/firebase/storage-download.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>sidenav.service.ts</strong> <code>Track first menu request to enable lazy sidenav menu loading</code> <code>+21/-19</code></summary>

<br/>

>Track first menu request to enable lazy sidenav menu loading
>
><pre>
>• Adds a menuRequested signal that is set on open/toggle, and reformats the service. This signal is used by the app shell to defer the menu component until the user interacts with the sidenav.
></pre>
>
><a href='https://github.com/daveryderoxford/ScoreSmarter/pull/62/files#diff-4a12c652e49c069e1cd49247d50ee17c65a9a90be62df7e3aa7d8c6129630d6a'>sailbrowser-web/src/app/shared/services/sidenav.service.ts</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Bug fix</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>app-update.service.ts</strong> <code>Make service-worker update polling and prompts zoneless-safe</code> <code>+57/-22</code></summary>

<br/>

>Make service-worker update polling and prompts zoneless-safe
>
><pre>
>• Changes update checks to wait for navigator.serviceWorker.ready and then poll on a fixed interval; also retries checks on tab visibility changes. Uses afterNextRender with an EnvironmentInjector to ensure snackbar UI is scheduled correctly when SW events occur outside Angular.
></pre>
>
><a href='https://github.com/daveryderoxford/ScoreSmarter/pull/62/files#diff-b14b63fd4fe4f09ed33aa492899707dd8ade5e7f820acaa69c414c0bbad6c8ff'>sailbrowser-web/src/app/shared/services/app-update.service.ts</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Refactor</strong> (7)</summary>

<blockquote>
<details>
<summary><strong>app.ts</strong> <code>Align root component with sidenav service API and naming</code> <code>+3/-3</code></summary>

<br/>

>Align root component with sidenav service API and naming
>
><pre>
>• Renames the injected sidenav service field to protected readonly sidenavService and updates the init call to setSidenav(). This supports the new template dependency on sidenavService.menuRequested().
></pre>
>
><a href='https://github.com/daveryderoxford/ScoreSmarter/pull/62/files#diff-78d9f0a29f702d6f8be0e24cf27f2de614c128a2a8ba460c79f073520f4bd13b'>sailbrowser-web/src/app/app.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>club-settings.ts</strong> <code>Remove computed logoDisplayUrl in favor of template branching</code> <code>+1/-7</code></summary>

<br/>

>Remove computed logoDisplayUrl in favor of template branching
>
><pre>
>• Drops the computed logoDisplayUrl signal and its associated import. The template now directly chooses between pending preview &lt;img&gt; and &lt;app-club-logo&gt;.
></pre>
>
><a href='https://github.com/daveryderoxford/ScoreSmarter/pull/62/files#diff-46ee813eaf215f16466151c1b841ca13d49f8ec859b6a8958afe371ff85e4ddd'>sailbrowser-web/src/app/club-admin/presentation/club-settings/club-settings.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>home-page.scss</strong> <code>Remove races section styles now owned by extracted component</code> <code>+0/-11</code></summary>

<br/>

>Remove races section styles now owned by extracted component
>
><pre>
>• Deletes .races-section and .races-title rules from the home page stylesheet since the races UI was moved into a dedicated component.
></pre>
>
><a href='https://github.com/daveryderoxford/ScoreSmarter/pull/62/files#diff-b85bd4e88e72a7955b3faed99065a48eb3b3e3a3f595437550cc005866744c6e'>sailbrowser-web/src/app/home/presentation/home-page.scss</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>home-page.ts</strong> <code>Extract races section dependency and simplify home component imports</code> <code>+6/-14</code></summary>

<br/>

>Extract races section dependency and simplify home component imports
>
><pre>
>• Removes CurrentRaces, DatePipe, MatList, and ClubLogoService usage from the home page and adds the new HomeRacesSection import. Keeps title computation and effect with minor formatting cleanup.
></pre>
>
><a href='https://github.com/daveryderoxford/ScoreSmarter/pull/62/files#diff-73298b0e2824252480dbc41a6c1fd8fa4a3b3e0efd0c3667b3fca49de9daf439'>sailbrowser-web/src/app/home/presentation/home-page.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>club-logo.html</strong> <code>Render logo image based on service-resolved URL</code> <code>+2/-2</code></summary>

<br/>

>Render logo image based on service-resolved URL
>
><pre>
>• Changes the template condition and [src] binding to use logoUrl() rather than an input src(). This aligns with the new service-driven ClubLogo behavior.
></pre>
>
><a href='https://github.com/daveryderoxford/ScoreSmarter/pull/62/files#diff-14372cd3e5c9c53b2cd4eb53bfec8410b0812f409b11f531addc25439e3e1890'>sailbrowser-web/src/app/shared/components/club-logo/club-logo.html</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>sidenav-menu.html</strong> <code>Stop passing explicit club logo URL to ClubLogo component</code> <code>+0/-1</code></summary>

<br/>

>Stop passing explicit club logo URL to ClubLogo component
>
><pre>
>• Removes the [src] binding from &lt;app-club-logo&gt;, relying on the shared component to resolve its own URL via service.
></pre>
>
><a href='https://github.com/daveryderoxford/ScoreSmarter/pull/62/files#diff-242604dea34b6837595ba9a93d99727eba17e9093fdb5f66611b601bcd385703'>sailbrowser-web/src/app/sidenav-menu/presentation/sidenav-menu.html</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>sidenav-menu.ts</strong> <code>Remove ClubLogoService dependency from sidenav menu</code> <code>+0/-2</code></summary>

<br/>

>Remove ClubLogoService dependency from sidenav menu
>
><pre>
>• Drops the ClubLogoService import and injection since the ClubLogo component now handles URL resolution internally. This reduces eager service usage when the menu is deferred.
></pre>
>
><a href='https://github.com/daveryderoxford/ScoreSmarter/pull/62/files#diff-2249f9006964149db8f34eec8f830fc56061a64f1e371a7462eca8bbcad1c334'>sailbrowser-web/src/app/sidenav-menu/presentation/sidenav-menu.ts</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>